### PR TITLE
Simplify integer.js

### DIFF
--- a/lib/deserialize/integer.js
+++ b/lib/deserialize/integer.js
@@ -8,28 +8,20 @@
  * @returns {{position: {Number}, value: {Number}}}
  */
 function integer(buffer, position) {
-  let integer = buffer[position++];
-  let digitArray = [];
+  const result = { position, value: 0 };
 
-  let numBytes = 0;
+  do {
+    /* Shift the existing value left for 7 bits (base127 conversion)
+       and merge it with the next value without its highest bit */
+    result.value = (result.value << 7) | (buffer[result.position] & 127);
 
-  // if the most significant bit is set, the the integer continues
-  while (integer >= 128) {
-    digitArray.unshift(integer - 128);
-    integer = buffer[position++];
-    if (numBytes > 1000) {
-      throw new Error('Integer is probably too long')
+    /* Avoid Number overflows */
+    if (result.value < 0) {
+      throw new Error('RFC 3284 Integer conversion: Buffer overflow');
     }
-    numBytes++;
-  }
+  } while (buffer[result.position++] & 128);
 
-  digitArray.unshift(integer);
-
-  // convert from base 128 to decimal
-  return {
-    position: position,
-    value: digitArray.reduce((sum, digit, index) => sum + digit * Math.pow(128, index), 0)
-  };
+  return result;
 }
 
 module.exports = integer;


### PR DESCRIPTION
Instead of using an array buffer and allowing up to 1000 bytes (which will probably not cover overflows), we can do the conversion on the fly to the expected result object and catch overflows at the same time.