### PR TITLE
Adding support for xDelta generated vcdiff

### DIFF
--- a/lib/instructions.js
+++ b/lib/instructions.js
@@ -62,7 +62,7 @@ COPY.prototype.execute = function(delta) {
 RUN.prototype.execute = function(delta) {
   for (let i = 0; i < this.size; i++) {
     // repeat single byte
-    delta.U[delta.UTargetPosition + i] = delta.data[delta.dataPosition];
+    delta.U.set(delta.UTargetPosition + i, delta.data[delta.dataPosition]);
   }
   // increment to next byte
   delta.dataPosition++;

--- a/lib/tokenize_instructions.js
+++ b/lib/tokenize_instructions.js
@@ -78,7 +78,7 @@ function tokenizeInstructions(instructionsBuffer) {
       deserializedInstructions.push(new instructions.COPY(size, 7));
     }
     else if (index < 147) {
-      deserializedInstructions.push(new instructions.COPY(index - 127, 7));
+      deserializedInstructions.push(new instructions.COPY(index - 128, 7));
     }
     else if (index === 147) {
       ({ value: size, position: instructionsPosition } = deserializeInteger(instructionsBuffer, instructionsPosition));
@@ -160,7 +160,7 @@ function ADD_COPY(index, baseIndex) {
   // offset so size starts at 4
   let copySize = copySizeIndex + 4;
 
-  return [addSize, copySize];
+  return {addSize, copySize};
 }
 
 module.exports = tokenizeInstructions;

--- a/lib/typed_array_util.js
+++ b/lib/typed_array_util.js
@@ -75,6 +75,11 @@ TypedArrayList.prototype.set = function(index, value) {
 };
 
 function getIndex(arr, element) {
+  // Performance optimization for most common case
+  if (arr.length === 2) {
+    return element < arr[1] ? 0 : 1;
+  }
+
   let low = 0;
   let high = arr.length - 1;
 

--- a/lib/vcdiff.js
+++ b/lib/vcdiff.js
@@ -127,8 +127,7 @@ VCDiff.prototype._buildTargetWindow = function(position, sourceSegment) {
     instruction.execute(delta);
   });
 
-  let target = U.typedArrays[1];
-  this.targetWindows.add(target);
+  this.targetWindows.add(T);
 };
 
 function Delta(U, UTargetPosition, data, addresses) {

--- a/lib/vcdiff.js
+++ b/lib/vcdiff.js
@@ -94,6 +94,14 @@ VCDiff.prototype._consumeWindow = function() {
       'non-zero VCD_TARGET in Win_Indicator'
     )
   }
+  else {
+    let deltaLength;
+    ({ value: deltaLength, position: this.position } = deserializeInteger(this.delta, this.position));
+
+    this._buildTargetWindow(this.position);
+    this.position += deltaLength;
+  }
+
   return this.position < this.delta.length;
 };
 
@@ -104,13 +112,17 @@ VCDiff.prototype._buildTargetWindow = function(position, sourceSegment) {
   let T = new Uint8Array(window.targetWindowLength);
 
   let U = new TypedArray.TypedArrayList();
-  U.add(sourceSegment);
+  let uTargetPosition = 0;
+  if (sourceSegment) {
+    U.add(sourceSegment);
+    uTargetPosition = sourceSegment.length;
+  }
   U.add(T);
 
   let targetPosition = this.source.length;
   let dataPosition = 0;
 
-  let delta = new Delta(U, this.source.length, window.data, window.addresses);
+  let delta = new Delta(U, uTargetPosition, window.data, window.addresses);
   window.instructions.forEach(instruction => {
     instruction.execute(delta);
   });


### PR DESCRIPTION
Added/fixed support for the set of VCDifff instructions and header flags used by xDelta. 

- Handled delta application when VCD_SOURCE and VCD_TARGET are both 0
- Fixed  ADDCOPY instructions execution
- Fixed implementation of RUN instruction
- Fixed the implementation of `10.  COPY   0, [4,18]     7     NOOP       0        0    [131,146]`
- All instructions in RFC3284 Section 5.6 were tested
- Some performance optimizations

In essence this should turn the library to producer agnostic VCDiff application tool. Only VCD_TARGET=1 should be out of support now.
 